### PR TITLE
Update to oh-my-zsh.sh - Issue #7332

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -64,7 +64,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${ZSH}}/cache/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then


### PR DESCRIPTION
Improvement to issue number  #7332
updated my oh-my-zsh.sh file - because of the same reason "it looks like this is because regardless of the set $ZSH directory the ZSH_COMPDUMP file is always set to point to the $HOME directory."
```
# Save the location of the current completion dump file.
if [ -z "$ZSH_COMPDUMP" ]; then
  ZSH_COMPDUMP="${ZDOTDIR:-${ZSH}}/cache/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
fi
```
Replacing ${HOME}} with ${ZSH}}/cache
I think this is much more tidy way of doing things.