### PR TITLE
Improvement to issue number #7688 & #7686 for MacOS -"plugin not found"

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -42,7 +42,8 @@ is_plugin() {
   local base_dir=$1
   local name=$2
   test -f $base_dir/plugins/$name/$name.plugin.zsh \
-    || test -f $base_dir/plugins/$name/_$name
+    || test -f $base_dir/plugins/$name/_$name \
+    || test -f $base_dir/$name/
 }
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
@@ -51,6 +52,13 @@ for plugin ($plugins); do
     fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
   elif is_plugin $ZSH $plugin; then
     fpath=($ZSH/plugins/$plugin $fpath)
+    # Add elif branch for MacOS and Homebrew
+  elif [[ "$OSTYPE" = darwin* ]]; then
+      if is_plugin /usr/local/Cellar $plugin; then
+        fpath=( /usr/local/Cellar/$plugin $fpath)
+      fi
+  else
+    echo "Warning: plugin $plugin not found"
   fi
 done
 


### PR DESCRIPTION
As MacOS users may have ZSH plugins installed via Homebrew the normal oh-my-zsh will not search the brew plugin directory
added search and fpath update for:
````
/usr/local/Cellar/$plugin
````